### PR TITLE
🔧 (trunk): Add plugin.yaml file used by trunk

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,18 +2,19 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.19.0
+  version: 1.20.0
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: gitmoji
       local: trunk/actions/gitmoji
     - id: trunk
-      ref: v1.4.2
+      ref: v1.4.3
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
+    - go@1.21.0
     - node@18.12.1
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
@@ -23,17 +24,17 @@ lint:
     - trufflehog # I prefer to use GitLeaks instead
   enabled:
     - actionlint@1.6.26
-    - checkov@3.1.70
+    - checkov@3.2.21
     - git-diff-check
-    - gitleaks@8.18.1
-    - markdownlint@0.38.0
-    - osv-scanner@1.6.1
-    - prettier@3.2.4
+    - gitleaks@8.18.2
+    - markdownlint@0.39.0
+    - osv-scanner@1.6.2
+    - prettier@3.2.5
     - terraform@1.7.0:
         commands: [validate, fmt]
-    - tflint@0.50.2
-    - trivy@0.48.3
-    - yamllint@1.33.0
+    - tflint@0.50.3
+    - trivy@0.49.1
+    - yamllint@1.35.0
 actions:
   enabled:
     - trunk-check-pre-commit

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,2 @@
+version: 0.1
+required_trunk_version: ">=1.19.0"


### PR DESCRIPTION
Trunk requires a plugin.yaml file in the root directory if we want to
use this repo as trunk plugin
